### PR TITLE
manually grab linuxbrew versions

### DIFF
--- a/singularity
+++ b/singularity
@@ -1,9 +1,9 @@
 #!/bin/bash
-conda list | tail -n+3 | awk '{print $1, $2, "Anaconda"}' > temp.info
-brew list --versions | awk '{print $0, "Homebrew"}'>> temp.info
-julia --version | awk '{print $1, $3, "User_Install"}' >> temp.info
-rtg version | head -1 | awk '{print $2, $5, "User_Install"}' >> temp.info
-column -t temp.info | sort -u --ignore-case
-rm temp.info
+conda list | tail -n+3 | awk '{print $1, $2, "Anaconda"}' > /tmp/temp.info
+find /Software/.linuxbrew/Cellar -maxdepth 2 -print | sed 's|/Software/.linuxbrew/Cellar||g' | sed 's|^/||' | grep "/" | sed 's|/|\t|' | sort | awk '{print $1, $2, "Homebrew"}'>> /tmp/temp.info
+julia --version | awk '{print $1, $3, "User_Install"}' >> /tmp/temp.info
+rtg version | head -1 | awk '{print $2, $5, "User_Install"}' >> /tmp/temp.info
+column -t /tmp/temp.info | sort -u --ignore-case
+rm /tmp/temp.info
 printf "\n"
 R -e 'installed.packages(fields = c("Package", "Version"))[,c("Package", "Version")]' | tail -n+22 | grep -v '^>' | awk '{print $1, $3, "R_package"}' | perl -pe 's/"//g' | sort -u --ignore-case | column -t


### PR DESCRIPTION
brew list was failing with `Error: The current working directory doesn't exist, cannot proceed`
